### PR TITLE
Update EPEL 7 url

### DIFF
--- a/snippets/per_osmajor/system/RedHatEnterpriseLinux7
+++ b/snippets/per_osmajor/system/RedHatEnterpriseLinux7
@@ -1,1 +1,1 @@
-repo --name=epel --baseurl=http://download.fedoraproject.org/pub/epel/$releasever/$basearch --install
+repo --name=epel --baseurl=http://download.fedoraproject.org/pub/archive/epel/$releasever/$basearch --install


### PR DESCRIPTION
EPEL 7 has been archived and so this updates the EPEL url to the archive url.

Signed-off-by: Cody Cheng <ccheng@iol.unh.edu>