### PR TITLE
Use ansible snippet

### DIFF
--- a/snippets/per_osmajor/system/Fedora31
+++ b/snippets/per_osmajor/system/Fedora31
@@ -1,3 +1,7 @@
 # Fedora31 per os major system snippet
 repo --name=Fedora-Everything --metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch --install
 repo --name=Fedora-Everything-Updates --metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-released-f$releasever&arch=$basearch --install
+%post
+#here the [[:blank:]]* just means whitespace ( [[:blank:]] ) and then 0 or higher so we're essentially ignoring white space that could be between "enabled" and "="
+sed -i 's/^gpgcheck.*//g' /etc/yum.repos.d/* && sed -i 's/enabled[[:blank:]]*=[[:blank:]]*1/enabled=1 \ngpgcheck=0\n/g' /etc/yum.repos.d/*
+%end

--- a/snippets/per_osmajor/system_post/RedHatEnterpriseLinux8_post
+++ b/snippets/per_osmajor/system_post/RedHatEnterpriseLinux8_post
@@ -1,6 +1,0 @@
-# rhel8 per os major post
-cd /root
-git clone git://github.com/OpenFabrics/fsdp_setup
-pushd fsdp_setup
-./rdma-setup.sh
-popd

--- a/snippets/system_post
+++ b/snippets/system_post
@@ -1,6 +1,14 @@
 # global system_post snippet
 cd /root
 git clone https://github.com/OpenFabrics/fsdp_setup
-pushd fsdp_setup
-./rdma-setup.sh
-popd
+cd fsdp_setup
+chmod +x ansible/setup.sh
+./ansible/setup.sh
+
+%end
+
+# Run outside of chroot
+%post --nochroot
+rm -f /mnt/sysimage/etc/NetworkManager/system-connections/* /mnt/sysimage/etc/sysconfig/network-scripts/ifcfg-*
+cp /etc/NetworkManager/system-connections/* /mnt/sysimage/etc/NetworkManager/system-connections
+cp /etc/sysconfig/network-scripts/ifcfg-* /mnt/sysimage/etc/sysconfig/network-scripts


### PR DESCRIPTION
This updates the system_post kickstart script to use Ansible to setup the nodes. The Ansible Playbook uses nmcli to create the network interfaces during the beaker post install stage. For some reason, nmcli creates the network interface configuration files in the wrong directory so this beaker snippet also moves the configuration files to the correct directory.